### PR TITLE
LMOFreeform: Sidebar: Double item inserted bug & set alpha when is navigation bars is hidden & themed icons

### DIFF
--- a/sidebar/app/src/main/java/com/libremobileos/sidebar/service/SidebarComposeView.kt
+++ b/sidebar/app/src/main/java/com/libremobileos/sidebar/service/SidebarComposeView.kt
@@ -1,7 +1,10 @@
 package com.libremobileos.sidebar.service
 
+import android.graphics.drawable.AdaptiveIconDrawable
+import android.provider.Settings
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
@@ -14,7 +17,12 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import com.android.settingslib.spa.framework.compose.rememberDrawablePainter
 import com.libremobileos.sidebar.bean.AppInfo
@@ -26,6 +34,17 @@ fun SidebarComposeView(
     modifier: Modifier = Modifier
 ) {
     val sidebarAppList by viewModel.sidebarAppListFlow.collectAsState()
+    val context = LocalContext.current
+    val isDark = isSystemInDarkTheme()
+    val isThemedIconsEnabled by remember {
+        mutableStateOf(
+            Settings.System.getInt(
+                context.contentResolver,
+                "sidebar_themed_icons",
+                0
+            ) == 1
+        )
+    }
     Card(
         colors = CardDefaults.cardColors(
             containerColor = MaterialTheme.colorScheme.surfaceContainer
@@ -49,10 +68,23 @@ fun SidebarComposeView(
                 )
             }
             items(sidebarAppList) { appInfo ->
+                val adaptiveIconDrawable = if (appInfo.icon is AdaptiveIconDrawable) {
+                    appInfo.icon as AdaptiveIconDrawable
+                } else null
                 Image(
                     painter = rememberDrawablePainter(
-                        drawable = appInfo.icon
+                        drawable = if (isThemedIconsEnabled &&
+                            adaptiveIconDrawable?.monochrome != null
+                        )
+                            adaptiveIconDrawable.monochrome
+                        else appInfo.icon
                     ),
+                    colorFilter = if (isThemedIconsEnabled &&
+                            adaptiveIconDrawable?.monochrome != null
+                        ) {
+                        if (isDark) ColorFilter.tint(Color.White)
+                        else ColorFilter.tint(Color.Black)
+                    } else null,
                     contentDescription = appInfo.label,
                     modifier = Modifier
                         .size(50.dp)

--- a/sidebar/app/src/main/java/com/libremobileos/sidebar/service/SidebarService.kt
+++ b/sidebar/app/src/main/java/com/libremobileos/sidebar/service/SidebarService.kt
@@ -15,6 +15,7 @@ import android.os.IBinder
 import android.os.ServiceManager
 import android.os.UserHandle
 import android.view.View
+import android.view.WindowInsets
 import android.view.WindowManager
 import android.view.WindowManager.LayoutParams
 import android.widget.Toast
@@ -50,6 +51,14 @@ class SidebarService : Service(), SharedPreferences.OnSharedPreferenceChangeList
             setOnTouchListener { _, event ->
                 gestureManager.onTouchEvent(event)
                 true
+            }
+            setOnApplyWindowInsetsListener { view, insets ->
+                view.alpha = if(!insets.isVisible(WindowInsets.Type.navigationBars())){
+                    0.1f
+                } else {
+                    1.0f
+                }
+                return@setOnApplyWindowInsetsListener insets
             }
         }
     }

--- a/sidebar/app/src/main/java/com/libremobileos/sidebar/ui/sidebar/SidebarSettingsPage.kt
+++ b/sidebar/app/src/main/java/com/libremobileos/sidebar/ui/sidebar/SidebarSettingsPage.kt
@@ -62,6 +62,9 @@ fun SidebarSettingsPage(
                     override val onCheckedChange: (Boolean) -> Unit = {
                         mainChecked.value = it
                         viewModel.setSidebarEnabled(it)
+                        if(!it) {
+                            viewModel.deleteAllSidebarApps()
+                        }
                     }
                 })
 

--- a/sidebar/app/src/main/java/com/libremobileos/sidebar/ui/sidebar/SidebarSettingsPage.kt
+++ b/sidebar/app/src/main/java/com/libremobileos/sidebar/ui/sidebar/SidebarSettingsPage.kt
@@ -1,5 +1,6 @@
 package com.libremobileos.sidebar.ui.sidebar
 
+import android.provider.Settings
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
@@ -12,8 +13,10 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.navigation.compose.rememberNavController
 import com.android.settingslib.spa.framework.compose.localNavController
@@ -33,6 +36,17 @@ fun SidebarSettingsPage(
 ) {
     val navController = rememberNavController()
     var mainChecked = rememberSaveable { mutableStateOf(viewModel.getSidebarEnabled()) }
+    val context = LocalContext.current
+    val themedIconsProp = "sidebar_themed_icons"
+    var isThemedIconsEnabled by remember {
+        mutableStateOf(
+            Settings.System.getInt(
+                context.contentResolver,
+                themedIconsProp,
+                0
+            ) == 1
+        )
+    }
 
     CompositionLocalProvider(navController.localNavController()) {
         SettingsScaffold(
@@ -50,6 +64,22 @@ fun SidebarSettingsPage(
                         viewModel.setSidebarEnabled(it)
                     }
                 })
+
+                SwitchPreference(
+                    model = object : SwitchPreferenceModel {
+                        override val title = stringResource(R.string.sidebar_themed_icons_label)
+                        override val checked = { isThemedIconsEnabled }
+                        override val onCheckedChange: (Boolean) -> Unit = {
+                            isThemedIconsEnabled = it
+                            Settings.System.putInt(
+                                context.contentResolver,
+                                themedIconsProp,
+                                if (it) 1 else 0
+                            )
+                        }
+                    },
+                )
+
                 if (mainChecked.value) {
                     SidebarAppList(viewModel)
                 }

--- a/sidebar/app/src/main/java/com/libremobileos/sidebar/ui/sidebar/SidebarSettingsViewModel.kt
+++ b/sidebar/app/src/main/java/com/libremobileos/sidebar/ui/sidebar/SidebarSettingsViewModel.kt
@@ -101,6 +101,10 @@ class SidebarSettingsViewModel(private val application: Application) : AndroidVi
     fun deleteSidebarApp(appInfo: SidebarAppInfo) {
         repository.deleteSidebarApp(appInfo.packageName, appInfo.activityName, appInfo.userId)
     }
+	
+    fun deleteAllSidebarApps() {
+        repository.deleteAllSidebar()
+    }
 
     private fun initAllAppList() {
         viewModelScope.launch(Dispatchers.IO) {

--- a/sidebar/app/src/main/res/values/strings.xml
+++ b/sidebar/app/src/main/res/values/strings.xml
@@ -6,4 +6,5 @@
     <string name="sidebar_label">Sidebar</string>
     <string name="sidebar_summary">Quickly open apps in a floating window</string>
     <string name="sidebar_app_setting_label">Pinned apps</string>
+    <string name="sidebar_themed_icons_label">Use sidebar with themed icons</string>
 </resources>


### PR DESCRIPTION
Enable use sidebar
Enable an app
Disable use sidebar
Previous enabled app now is disabled in page but it exists in sidebarview

![sidebara](https://github.com/user-attachments/assets/73873a33-d381-401d-9f4f-218387929175)
![sidebarb](https://github.com/user-attachments/assets/fc59e20e-c63e-4802-9768-153efd9a0380)
![sidebarc](https://github.com/user-attachments/assets/f06a949b-4604-4f01-8887-0630b094008d)
![sidebard](https://github.com/user-attachments/assets/7882ac3a-f7de-4f1d-afbc-1bdee3fb652a)

after fix ( Remove all sidebar apps from database after use sidebar disabled. )

![sidebaraa](https://github.com/user-attachments/assets/3f2b3b66-f220-4ace-b1e2-d5cad58aa5bc)
![sidebarab](https://github.com/user-attachments/assets/a80f3fca-4578-4eae-901d-5eb596a5b2da)
![sidebarac](https://github.com/user-attachments/assets/14c6ba26-43ad-456f-884c-ab4b06bbc8f2)

=============================================================

When the navigation bar is hidden, the sidebar becomes visible and this creates visual discomfort, so the alpha value has been reduced. (red arrows when alpha is 0.1f)

![sidebarf](https://github.com/user-attachments/assets/9665a167-8a30-474f-9389-e127b1dd7d31)
![sidebarfa](https://github.com/user-attachments/assets/37855c01-c467-46f0-8781-7673f98c85d4)
![sidebarfb](https://github.com/user-attachments/assets/41c083c0-e028-4677-bf22-f580c0cf8781)
![sidebarfc](https://github.com/user-attachments/assets/b3ca5cf7-4637-4e9a-86d2-f49b05f1599d)
![sidebarfd](https://github.com/user-attachments/assets/ea49f596-18f2-4165-8224-5abe50526d69)
![sidebarfe](https://github.com/user-attachments/assets/0efec5c1-f30e-4415-900f-d364eccde9f8)
![sidebarff](https://github.com/user-attachments/assets/c2a65892-7d76-4c71-b47d-38fbf55393fc)

=============================================================

In case of themed icons, sidebar icons remain normal and they are also made to comply with this situation. If the application has defined monochrome icons, that icon is used, if not defined, the default colored icon is used.

![sidebare](https://github.com/user-attachments/assets/df15ca98-2139-45a8-8af3-97a1ec2d087d)
![sidebarea](https://github.com/user-attachments/assets/7790b4d3-6df4-4541-9f7b-d78c3e2bb7ae)
![sidebareb](https://github.com/user-attachments/assets/9613d1cc-744b-42c2-a2b3-f03f36f2684d)
