### PR TITLE
SidebarService: Update alpha of sidebar based on statusBars visibility status instead of navigationBars visibility status and select LMOFreeform by default

### DIFF
--- a/app/src/main/java/com/libremobileos/freeform/receiver/StartFreeformReceiver.kt
+++ b/app/src/main/java/com/libremobileos/freeform/receiver/StartFreeformReceiver.kt
@@ -41,7 +41,7 @@ class StartFreeformReceiver : BroadcastReceiver() {
                 context.contentResolver,
                 "freeform_launch_mode",
                 0
-            ) == 0
+            ) != 0
             if (!ActivityManager.isHighEndGfx() || isNativeFreeformEnabled) {
                 launchAppInNativeFreeform(context, intent)
             } else {

--- a/sidebar/app/src/main/java/com/libremobileos/sidebar/service/SidebarService.kt
+++ b/sidebar/app/src/main/java/com/libremobileos/sidebar/service/SidebarService.kt
@@ -53,7 +53,7 @@ class SidebarService : Service(), SharedPreferences.OnSharedPreferenceChangeList
                 true
             }
             setOnApplyWindowInsetsListener { view, insets ->
-                view.alpha = if(!insets.isVisible(WindowInsets.Type.navigationBars())){
+                view.alpha = if(!insets.isVisible(WindowInsets.Type.statusBars())){
                     0.1f
                 } else {
                     1.0f


### PR DESCRIPTION
Bug: 

Settings -> System -> Navigation Mode -> Gesture navigation -> Settings icon -> Disable navigation hint
Settings -> System -> Navigation Mode -> Disable navigation bar

When the user hides the navbar, the alpha value of the sidebar will always be 0.1f because this change is triggered last and will not happen again when needed. Therefore, it is more convenient to control the statusBar visibility instead.


The other patch also selected LMOFreeform by default. In the previous code, native Freeform was the priority. Even on devices capable of running LMOFreeform, if the user hasn't enabled Freeform in the developer settings, Native Freeform won't work, which creates a problem.

** In the previous code, users who want to run LMO Freeform can run
adb shell
settings put system freeform_launch_mode 1