### PR TITLE
AllAppActivity: Fix wrong padding

### DIFF
--- a/sidebar/app/src/main/java/com/libremobileos/sidebar/ui/all_app/AllAppActivity.kt
+++ b/sidebar/app/src/main/java/com/libremobileos/sidebar/ui/all_app/AllAppActivity.kt
@@ -37,7 +37,7 @@ class AllAppActivity: ComponentActivity() {
             contentResolver,
             "freeform_launch_mode",
             0
-        ) == 0
+        ) != 0
 
         setContent {
             SidebarTheme {


### PR DESCRIPTION
Before

<img width="360" height="720" alt="crdroid1" src="https://github.com/user-attachments/assets/42708777-42e1-4eef-8006-52d6745e549a" />
<img width="360" height="720" alt="crdroid2" src="https://github.com/user-attachments/assets/2788868b-c508-4163-bb87-b7a0d57128c5" />


After
<img width="360" height="720" alt="crdroid3" src="https://github.com/user-attachments/assets/77282c11-cc74-4370-988e-33b6ed410a77" />
<img width="360" height="720" alt="crdroid4" src="https://github.com/user-attachments/assets/71ccbd8f-3fbc-4bae-869c-cb5ed7c01144" />
